### PR TITLE
Make modular for the use in other states for logfile watching

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,8 @@
 beaver-formula
 ==============
-
+NOTE! This formula is for machines that run python2 natively. 
+As python2 has been deprecated in salt and most OS's
+this has been left for historical purposes. 
 SaltStack formula to install Beaver Logstash ( http://logstash.net ) agent.
 
 Salt state for installing Beaver - https://github.com/josegonzalez/beaver

--- a/beaver/files/beaver.conf
+++ b/beaver/files/beaver.conf
@@ -4,6 +4,7 @@
 {% set logstash_version = global.get('logstash_version', '1') -%}
 {% set queue_timeout = global.get('queue_timeout', '60') -%}
 {% set sincedb_path = global.get('sincedb_path', none) -%}
+{% set logfiles = global.get('logfiles', none) -%}
 {% set format = global.get('format', 'json') -%}
 
 [beaver]
@@ -110,7 +111,7 @@ udp_port: {{ port }}
 
 {% endif -%}
 
-{% if logfiles -%}
+{% if logfiles is not none -%}
 {% for log in logfiles -%}
 
 [{{ log.log_path }}]

--- a/beaver/files/beaver.conf
+++ b/beaver/files/beaver.conf
@@ -4,7 +4,6 @@
 {% set logstash_version = global.get('logstash_version', '1') -%}
 {% set queue_timeout = global.get('queue_timeout', '60') -%}
 {% set sincedb_path = global.get('sincedb_path', none) -%}
-{% set logfiles = global.get('logfiles', none) -%}
 {% set format = global.get('format', 'json') -%}
 
 [beaver]
@@ -111,7 +110,7 @@ udp_port: {{ port }}
 
 {% endif -%}
 
-{% if logfiles is not none -%}
+{% if logfiles -%}
 {% for log in logfiles -%}
 
 [{{ log.log_path }}]

--- a/beaver/files/beaver.conf
+++ b/beaver/files/beaver.conf
@@ -110,7 +110,7 @@ udp_port: {{ port }}
 
 {% endif -%}
 
-{% if logfiles is not none -%}
+{% if logfiles -%}
 {% for log in logfiles -%}
 
 [{{ log.log_path }}]

--- a/beaver/files/beaver.conf
+++ b/beaver/files/beaver.conf
@@ -110,6 +110,7 @@ udp_port: {{ port }}
 
 {% endif -%}
 
+{% if logfiles is not none -%}
 {% for log in logfiles -%}
 
 [{{ log.log_path }}]
@@ -130,3 +131,4 @@ sincedb_write_interval: {{ sincedb_write_interval }}
 {% endif -%}
 
 {% endfor -%}
+{% endif -%}

--- a/beaver/files/beaver.conf
+++ b/beaver/files/beaver.conf
@@ -110,7 +110,7 @@ udp_port: {{ port }}
 
 {% endif -%}
 
-{% if logfiles -%}
+{% if logfiles is defined -%}
 {% for log in logfiles -%}
 
 [{{ log.log_path }}]

--- a/beaver/files/beaver_systemd.conf
+++ b/beaver/files/beaver_systemd.conf
@@ -1,0 +1,11 @@
+[Unit]
+Description=File Shipper
+After=network.target
+
+[Service]
+Type=simple
+User=root
+ExecStart=/usr/local/bin/beaver {{ beaver_opts }}
+
+[Install]
+WantedBy=multi-user.target

--- a/beaver/init.sls
+++ b/beaver/init.sls
@@ -43,9 +43,7 @@ beaver:
   service.running:
     - enable: True
     - watch:
-      - file: /etc/beaver/beaver.conf
-    - onchanges:
-      - file: /etc/beaver/conf.d/*
+      - file: /etc/beaver/*
     {% if grains['os_family'] == 'Debian' %}
     - require:
       - file: /etc/init.d/beaver

--- a/beaver/init.sls
+++ b/beaver/init.sls
@@ -58,6 +58,7 @@ beaver:
     - group: root
     - mode: 755
     - makedirs: True
+
 /etc/beaver/conf.d:
   file.directory:
     - usear: root

--- a/beaver/init.sls
+++ b/beaver/init.sls
@@ -2,6 +2,7 @@
 
 {% set transport_type = beaver.transport_type|default('stdout') %}
 {% set virtualenv = beaver.virtualenv|default(false) %}
+{% set logfiles = beaver.logfiles|default(false) %}
 
 {% set beaver_opts = '-c /etc/beaver/beaver.conf -C /etc/beaver/conf.d' %}
 {% set beaver_logfile = '/var/log/beaver/beaver.log' %}
@@ -82,7 +83,9 @@ beaver:
     - source: salt://beaver/files/beaver.conf
     - context:
         global: {{ beaver.global }}
-#       logfiles: {{ beaver.logfiles }}
+{% if logfiles %}
+        logfiles: {{ beaver.logfiles }}
+{% endif %}
     - require:
       - file: /etc/beaver
 

--- a/beaver/init.sls
+++ b/beaver/init.sls
@@ -52,6 +52,12 @@ beaver:
       - file: /etc/init.d/beaver.conf
     {% endif %}
 
+/etc/beaver:
+  file.directory:
+    - usear: root
+    - group: root
+    - mode: 755
+    - makedirs: True
 /etc/beaver/conf.d:
   file.directory:
     - usear: root
@@ -75,7 +81,9 @@ beaver:
     - source: salt://beaver/files/beaver.conf
     - context:
         global: {{ beaver.global }}
+{% if beaver.logfiles is not none -%}
         logfiles: {{ beaver.logfiles }}
+{% endif -%}
     - require:
       - file: /etc/beaver
 

--- a/beaver/init.sls
+++ b/beaver/init.sls
@@ -44,14 +44,14 @@ beaver:
     - enable: True
     - watch:
       - file: /etc/beaver/*
-    {% if grains['os_family'] == 'Debian' %}
+    {% if grains['init'] == 'systemd' %}
+    - require:
+      - file: /etc/systemd/system/beaver.service
+    {% else %}
     - require:
       - file: /etc/init.d/beaver
       - file: /var/log/beaver
       - file: /etc/beaver
-    {% elif grains['os_family'] == 'Redhat' %}
-    - require:
-      - file: /etc/init.d/beaver.conf
     {% endif %}
 
 /etc/beaver:
@@ -90,21 +90,18 @@ beaver:
     - require:
       - file: /etc/beaver
 
-{% if grains['os_family'] == 'Redhat' %}
-/etc/init.d/beaver.conf:
+{% if grains['init'] == 'systemd' %}
+/etc/systemd/system/beaver.service:
   file.managed:
     - user: root
     - group: root
     - mode: 755
     - template: jinja
-    - source: salt://beaver/files/beaver_init.conf
+    - source: salt://beaver/files/beaver_systemd.conf
     - context:
         beaver_path: {{ beaver_path }}
         beaver_opts: {{ beaver_opts }}
-        beaver_logfile: {{ beaver_logfile }}
-{% endif %}
-
-{% if grains['os_family'] == 'Debian' %}
+{% else %}
 /etc/init.d/beaver:
   file.managed:
     - user: root

--- a/beaver/init.sls
+++ b/beaver/init.sls
@@ -47,6 +47,8 @@ beaver:
     {% if grains['os_family'] == 'Debian' %}
     - require:
       - file: /etc/init.d/beaver
+      - file: /var/log/beaver
+      - file: /etc/beaver
     {% elif grains['os_family'] == 'Redhat' %}
     - require:
       - file: /etc/init.d/beaver.conf

--- a/beaver/init.sls
+++ b/beaver/init.sls
@@ -82,9 +82,7 @@ beaver:
     - source: salt://beaver/files/beaver.conf
     - context:
         global: {{ beaver.global }}
-{% if beaver.logfiles is not none -%}
-        logfiles: {{ beaver.logfiles }}
-{% endif -%}
+#       logfiles: {{ beaver.logfiles }}
     - require:
       - file: /etc/beaver
 

--- a/beaver/init.sls
+++ b/beaver/init.sls
@@ -44,6 +44,7 @@ beaver:
     - enable: True
     - watch:
       - file: /etc/beaver/beaver.conf
+    - onchanges:
       - file: /etc/beaver/conf.d/*
     {% if grains['os_family'] == 'Debian' %}
     - require:

--- a/beaver/init.sls
+++ b/beaver/init.sls
@@ -3,7 +3,7 @@
 {% set transport_type = beaver.transport_type|default('stdout') %}
 {% set virtualenv = beaver.virtualenv|default(false) %}
 
-{% set beaver_opts = '-c /etc/beaver/beaver.conf' %}
+{% set beaver_opts = '-c /etc/beaver/beaver.conf -C /etc/beaver/conf.d' %}
 {% set beaver_logfile = '/var/log/beaver/beaver.log' %}
 
 {% if virtualenv %}
@@ -43,6 +43,7 @@ beaver:
     - enable: True
     - watch:
       - file: /etc/beaver/beaver.conf
+      - file: /etc/beaver/conf.d/*
     {% if grains['os_family'] == 'Debian' %}
     - require:
       - file: /etc/init.d/beaver
@@ -51,7 +52,7 @@ beaver:
       - file: /etc/init.d/beaver.conf
     {% endif %}
 
-/etc/beaver:
+/etc/beaver/conf.d:
   file.directory:
     - usear: root
     - group: root

--- a/beaver/map.jinja
+++ b/beaver/map.jinja
@@ -1,6 +1,6 @@
 {% set beaver = salt['grains.filter_by']({
     'Debian': {
-        'pip': 'pip2',
+        'pip': 'python-pip',
         'python-virtualenv': 'python-virtualenv',
         'zmq': 'libzmq-dev',
     },

--- a/beaver/map.jinja
+++ b/beaver/map.jinja
@@ -1,6 +1,6 @@
 {% set beaver = salt['grains.filter_by']({
     'Debian': {
-        'pip': 'pythone-pip',
+        'pip': 'python3-pip',
         'python-virtualenv': 'python-virtualenv',
         'zmq': 'libzmq-dev',
     },

--- a/beaver/map.jinja
+++ b/beaver/map.jinja
@@ -1,6 +1,6 @@
 {% set beaver = salt['grains.filter_by']({
     'Debian': {
-        'pip': 'python2-pip',
+        'pip': 'pip2',
         'python-virtualenv': 'python-virtualenv',
         'zmq': 'libzmq-dev',
     },

--- a/beaver/map.jinja
+++ b/beaver/map.jinja
@@ -1,6 +1,6 @@
 {% set beaver = salt['grains.filter_by']({
     'Debian': {
-        'pip': 'python-pip',
+        'pip': 'pythone-pip',
         'python-virtualenv': 'python-virtualenv',
         'zmq': 'libzmq-dev',
     },

--- a/beaver/map.jinja
+++ b/beaver/map.jinja
@@ -1,6 +1,6 @@
 {% set beaver = salt['grains.filter_by']({
     'Debian': {
-        'pip': 'python3-pip',
+        'pip': 'python2-pip',
         'python-virtualenv': 'python-virtualenv',
         'zmq': 'libzmq-dev',
     },


### PR DESCRIPTION
Hey folks,

I've modded this to allow other states to generate beaver config and have beaver automatically include it. I've specifically used it to catch my apache error logs across instances and ship them. Let me know if anyone would find this useful. It also still handles the old config as expected in my testing so shouldn't have an impact on anyone else. Sample for the modular route follows:
/etc/beaver/conf.d/vhost-{{ vhost['servername'] }}.conf:
  file:
    - managed
    - source: salt://apache-vhosts/beaver-error.conf
    - user: root
    - group: root
    - mode: 0644
    - template: jinja
    - backup: minion
    - require: 
      - file: /etc/beaver/conf.d
    - context:
      servername: {{ vhost['servername'] }}
      apacheenv: {{ pillar['apacheenv'] }}
cat apache-vhost/beaver-error.conf 
[/var/www/vhosts/{{servername}}/statistics/logs/error_log]
type: apache-error
tags: {{apacheenv}},{{servername}}
