### PR TITLE
newer versions of centos no longer include python-pip instead using python2-pip

### DIFF
--- a/beaver/map.jinja
+++ b/beaver/map.jinja
@@ -5,7 +5,7 @@
         'zmq': 'libzmq-dev',
     },
     'RedHat': {
-        'pip': 'python-pip',
+        'pip': 'python2-pip',
         'python-virtualenv': 'python-virtualenv',
         'zmq': 'zeromq-devel',
     },


### PR DESCRIPTION
This allows us to upgrade to a newer version of the CentOS distribution.